### PR TITLE
TA#23398 fix translations and prefetch to partner fields

### DIFF
--- a/partner_organization_membership/__manifest__.py
+++ b/partner_organization_membership/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Partner Organization Membership",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "author": "Numigi",
     "maintainer": "Numigi",
     "website": "https://www.numigi.com",

--- a/partner_organization_membership/models/res_partner.py
+++ b/partner_organization_membership/models/res_partner.py
@@ -8,29 +8,34 @@ class ResPartner(models.Model):
 
     _inherit = "res.partner"
 
-    is_artist = fields.Boolean(string="Artist / Musician")
-    artisti = fields.Char(string="ARTISTI")
-    guilde = fields.Char(string="GUILDE")
-    sacem = fields.Char(string="SACEM")
-    socan = fields.Char(string="SOCAN")
-    sodrac = fields.Char(string="SODRAC")
-    sound_ex = fields.Char(string="SOUND EX.")
-    soproq = fields.Char(string="SOPROQ")
-    spacq = fields.Char(string="SPACQ")
-    uda = fields.Char(string="UDA")
+    is_artist = fields.Boolean(string="Artist / Musician", prefetch=False)
+    artisti = fields.Char(string="ARTISTI", prefetch=False)
+    guilde = fields.Char(string="GUILDE", prefetch=False)
+    sacem = fields.Char(string="SACEM", prefetch=False)
+    socan = fields.Char(string="SOCAN", prefetch=False)
+    sodrac = fields.Char(string="SODRAC", prefetch=False)
+    sound_ex = fields.Char(string="SOUND EX.", prefetch=False)
+    soproq = fields.Char(string="SOPROQ", prefetch=False)
+    spacq = fields.Char(string="SPACQ", prefetch=False)
+    uda = fields.Char(string="UDA", prefetch=False)
     organization_ids = fields.One2many(
-        "res.partner.organization", "partner_id", string="Other Organizations"
+        "res.partner.organization",
+        "partner_id",
+        string="Other Organizations",
+        prefetch=False,
     )
-    isni = fields.Char(string="ISNI")
-    ipi = fields.Char(string="IPI")
-    ipn = fields.Char(string="IPN")
-    is_canadian_artist = fields.Boolean(string="Canadian Artist")
-    is_resident_qc = fields.Boolean(string="Resident of Quebec")
-    is_emerging_artist = fields.Boolean(string="Emerging Artist")
-    is_closm = fields.Boolean(string="CLOSM")
-    is_autochthon = fields.Boolean(string="Autochthon")
-    is_visible_minority = fields.Boolean(string="Visible Minority")
-    birth_city_id = fields.Many2one("res.partner.birth.city", string="City of Birth")
+    isni = fields.Char(string="ISNI", prefetch=False)
+    ipi = fields.Char(string="IPI", prefetch=False)
+    ipn = fields.Char(string="IPN", prefetch=False)
+    is_canadian_artist = fields.Boolean(string="Canadian Artist", prefetch=False)
+    is_resident_qc = fields.Boolean(string="Resident of Quebec", prefetch=False)
+    is_emerging_artist = fields.Boolean(string="Emerging Artist", prefetch=False)
+    is_closm = fields.Boolean(string="CLOSM", prefetch=False)
+    is_autochthon = fields.Boolean(string="Autochthon", prefetch=False)
+    is_visible_minority = fields.Boolean(string="Visible Minority", prefetch=False)
+    birth_city_id = fields.Many2one(
+        "res.partner.birth.city", string="City of Birth", prefetch=False
+    )
 
     @api.onchange("company_type", "is_artist")
     def _onchange_company_type(self):

--- a/show_place/__manifest__.py
+++ b/show_place/__manifest__.py
@@ -2,23 +2,20 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 {
-    'name': 'Show Place',
-    'version': '1.0.0',
-    'author': 'Numigi',
-    'maintainer': 'Numigi',
-    'website': 'https://www.numigi.com',
-    'license': 'LGPL-3',
-    'category': 'Entertainment',
-    'summary': 'Add Show Place Types/Configuration',
-    'depends': [
-        'contacts',
-        'sales_team',
+    "name": "Show Place",
+    "version": "1.1.0",
+    "author": "Numigi",
+    "maintainer": "Numigi",
+    "website": "https://www.numigi.com",
+    "license": "LGPL-3",
+    "category": "Entertainment",
+    "summary": "Add Show Place Types/Configuration",
+    "depends": ["contacts", "sales_team"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/res_partner.xml",
+        "views/show_place_configuration.xml",
+        "views/show_place_type.xml",
     ],
-    'data': [
-        'security/ir.model.access.csv',
-        'views/res_partner.xml',
-        'views/show_place_configuration.xml',
-        'views/show_place_type.xml',
-    ],
-    'installable': True,
+    "installable": True,
 }

--- a/show_place/i18n/fr.po
+++ b/show_place/i18n/fr.po
@@ -203,8 +203,8 @@ msgid ""
 msgstr ""
 
 #. module: show_place
-#: model:ir.model.fields,field_description:show_place.field_res_partner__show_place_distance_from_montreal
-#: model:ir.model.fields,field_description:show_place.field_res_users__show_place_distance_from_montreal
+#: model:ir.model.fields,field_description:show_place.field_res_partner__show_place_distance_from_productor
+#: model:ir.model.fields,field_description:show_place.field_res_users__show_place_distance_from_productor
 #: model_terms:ir.ui.view,arch_db:show_place.res_partner_view_form_inherit_show
-msgid "Distance from Montreal"
-msgstr "Distance de Montréal"
+msgid "Distance from Productor"
+msgstr "Distance du producteur"

--- a/show_place/models/res_partner.py
+++ b/show_place/models/res_partner.py
@@ -6,22 +6,27 @@ from odoo import fields, models
 
 class ResPartner(models.Model):
 
-    _inherit = 'res.partner'
+    _inherit = "res.partner"
 
-    type = fields.Selection(selection_add=[('show_site', 'Show Site')])
+    type = fields.Selection(selection_add=[("show_site", "Show Site")])
     show_place_type_id = fields.Many2one(
-        'show.place.type', string="Show Place Type",
+        "show.place.type", string="Show Place Type", prefetch=False
     )
     show_place_configuration_id = fields.Many2one(
-        'show.place.configuration', string="Show Place Configuration",
-        ondelete='restrict',
+        "show.place.configuration",
+        string="Show Place Configuration",
+        ondelete="restrict",
+        prefetch=False,
     )
-    show_place_maximum_capacity = fields.Integer(string="Show Place Maximum capacity")
-    show_place_notes = fields.Text(string="Show Place Notes")
+    show_place_maximum_capacity = fields.Integer(
+        string="Show Place Maximum capacity", prefetch=False
+    )
+    show_place_notes = fields.Text(string="Show Place Notes", prefetch=False)
     show_place_minor_restriction = fields.Boolean(
         string="Show Place Minor Restriction",
-        help="Check this box if this place has a restriction for minors."
+        help="Check this box if this place has a restriction for minors.",
+        prefetch=False,
     )
-    show_place_distance_from_montreal = fields.Integer(
-        string="Distance from Montreal",
+    show_place_distance_from_productor = fields.Integer(
+        string="Distance from Productor", prefetch=False
     )

--- a/show_place/views/res_partner.xml
+++ b/show_place/views/res_partner.xml
@@ -26,8 +26,8 @@
                             <field name="show_place_minor_restriction"
                                    string="Minor Restriction"
                                    />
-                            <field name="show_place_distance_from_montreal"
-                                   string="Distance from Montreal"
+                            <field name="show_place_distance_from_productor"
+                                   string="Distance from Productor"
                                    />
                         </group>
                         <group/>

--- a/show_project/__manifest__.py
+++ b/show_project/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Show Project",
     "summary": "Show Project",
-    "version": "12.0.1.0.0",
+    "version": "1.1.0",
     "website": "https://bit.ly/numigi-com",
     "author": "Numigi",
     "maintainer": "Numigi",

--- a/show_project/i18n/fr.po
+++ b/show_project/i18n/fr.po
@@ -31,9 +31,9 @@ msgid "Configuration of Room"
 msgstr "Configuration de salle"
 
 #. module: show_project
-#: model:ir.model.fields,field_description:show_project.field_project_project__show_place_distance_from_montreal
-msgid "Distance from Montreal"
-msgstr "Distance de Montréal"
+#: model:ir.model.fields,field_description:show_project.field_project_project__show_place_distance_from_productor
+msgid "Distance from Productor"
+msgstr "Distance du producteur"
 
 #. module: show_project
 #: model:ir.model.fields,field_description:show_project.field_project_project__formula

--- a/show_project/models/project_project.py
+++ b/show_project/models/project_project.py
@@ -34,9 +34,9 @@ class ProjectProject(models.Model):
         related="show_place_id.show_place_minor_restriction",
         string="Minors Restriction",
     )
-    show_place_distance_from_montreal = fields.Integer(
-        related="show_place_id.show_place_distance_from_montreal",
-        string="Distance from Montreal",
+    show_place_distance_from_productor = fields.Integer(
+        related="show_place_id.show_place_distance_from_productor",
+        string="Distance from Productor",
     )
     show_place_notes = fields.Text(string="Notes")
     previous_show_id = fields.Many2one(

--- a/show_project/views/project_project.xml
+++ b/show_project/views/project_project.xml
@@ -61,7 +61,7 @@
                             <field name="show_place_maximum_capacity"/>
                             <field name="show_place_configuration"/>
                             <field name="show_place_minor_restriction"/>
-                            <field name="show_place_distance_from_montreal"/>
+                            <field name="show_place_distance_from_productor"/>
                             <field name="show_place_notes"/>
                             <field name="previous_show_id"/>
                             <field name="next_show_id"/>


### PR DESCRIPTION
The prefetch attribute prevents the server from crashing when updating modules.
This is important when adding fields to res.partner because this model is used
by the core when updating the system.