### PR TITLE
TA#24608 fix constraint on recording related to a product

### DIFF
--- a/recording_external_revenue/models/recording_external_revenue_raw.py
+++ b/recording_external_revenue/models/recording_external_revenue_raw.py
@@ -235,6 +235,9 @@ class RecordingExternalRevenueRaw(models.Model):
         if len(product) > 1:
             raise self._multiple_products_found_from_reference_error(product)
 
+        if not product.recording_id:
+            raise self._no_recording_related_to_product(product)
+
         return product
 
     def _no_product_found_from_reference_error(self):
@@ -271,7 +274,17 @@ class RecordingExternalRevenueRaw(models.Model):
         if len(product) > 1:
             raise self._multiple_products_found_from_catalog_error(catalog, product)
 
+        if not product.recording_id:
+            raise self._no_recording_related_to_product(product)
+
         return product
+
+    def _no_recording_related_to_product(self, product):
+        return ValidationError(
+            _("The product {} is not related to a recording.").format(
+                product.display_name
+            )
+        )
 
     def _no_product_found_from_catalog_error(self, catalog):
         raise ValidationError(
@@ -313,13 +326,8 @@ class RecordingExternalRevenueRaw(models.Model):
             return self._map_recording_from_catalog_reference()
 
     def _map_recording_from_product(self, product):
-        recording = product.recording_id
-        if not recording:
-            raise ValidationError(
-                _("The product {} is not related to a recording.").format(
-                    product.display_name
-                )
-            )
+        return product.recording_id
+
         return recording
 
     def _map_recording_from_isrc(self):

--- a/recording_external_revenue/tests/test_mapping.py
+++ b/recording_external_revenue/tests/test_mapping.py
@@ -119,6 +119,7 @@ class TestRawRevenueMapping(ExternalRevenueCase):
         assert revenue[field] == raw_revenue[field]
 
     def test_map_revenue_type(self):
+        self.stream.product_tmpl_id.recording_id = False
         raw_revenue = self._new_raw_revenue(revenue_type=self.stream_mapping.label)
         assert raw_revenue.make_new_revenue().product_id == self.stream
 


### PR DESCRIPTION
Only block when the product is mapped from a product reference
or a catalog reference.

In such case, the product is expected to be linked to a recording.

If the revenue type is used to map the product, the constraint is not
raised. A revenue type is not bound to a specific recording.