### PR TITLE
TA#41070 fix name of show projects

### DIFF
--- a/show_project/models/project_project.py
+++ b/show_project/models/project_project.py
@@ -103,7 +103,6 @@ class ProjectProject(models.Model):
     def _onchange_set_show_name(self):
         if self.show_type == "show":
             values = [
-                self.parent_id.display_name,
                 fields.Date.to_string(self.show_date),
                 self.show_place_id.display_name,
             ]

--- a/show_project/tests/test_show_project.py
+++ b/show_project/tests/test_show_project.py
@@ -106,9 +106,7 @@ class TestShowProject(SavepointCase):
         )
         self.assertEqual(
             form.name,
-            "{} - {} - {}".format(
-                self.tour_project_1.display_name, "2021-01-01", show_place.display_name
-            ),
+            "{} - {}".format("2021-01-01", show_place.display_name),
         )
 
     def test_project_city_is_set_by_related_show_place(self):


### PR DESCRIPTION
Otherwise, the name of the parent tour appears twice in the display
name of the show.