### PR TITLE
TA#42859 - Migrate fields from show_project_sale to show_project_promotion

### DIFF
--- a/show_project_promotion/i18n/fr.po
+++ b/show_project_promotion/i18n/fr.po
@@ -1,21 +1,24 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* show_project_promotion
+#	* show_project_promotion
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-04 19:38+0000\n"
-"PO-Revision-Date: 2021-08-04 15:40-0400\n"
+"POT-Creation-Date: 2022-03-24 09:13+0000\n"
+"PO-Revision-Date: 2022-03-24 09:13+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 2.3\n"
+
+#. module: show_project_promotion
+#: model:ir.model.fields,field_description:show_project_promotion.field_project_project__announcement_date
+msgid "Announcement Date"
+msgstr "Date d'annonce"
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_project__biography_url
@@ -35,12 +38,12 @@ msgstr "Créé le"
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_promotional_item__description
 msgid "Description"
-msgstr "Description"
+msgstr ""
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_promotional_item__display_name
 msgid "Display Name"
-msgstr "Nom d'affichage"
+msgstr "Nom affiché"
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_project__distributor_platform_url
@@ -50,27 +53,27 @@ msgstr "Plateforme du distributeur"
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_promotional_item__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_promotional_item____last_update
 msgid "Last Modified on"
-msgstr "Modifié la dernière fois le"
+msgstr "Dernière modification le"
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_promotional_item__write_uid
 msgid "Last Updated by"
-msgstr "Mis à jour la dernière fois par"
+msgstr "Dernière mise à jour par"
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_promotional_item__write_date
 msgid "Last Updated on"
-msgstr "Mis à jour pour la dernière fois le"
+msgstr "Dernière mise à jour le"
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_promotional_item__notes
 msgid "Notes"
-msgstr "Notes"
+msgstr ""
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_project__photo_gallery_url
@@ -96,7 +99,7 @@ msgstr "Article promotionnel sur projet"
 #. module: show_project_promotion
 #: model_terms:ir.ui.view,arch_db:show_project_promotion.project_form
 msgid "Promotion"
-msgstr "Promotion"
+msgstr ""
 
 #. module: show_project_promotion
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_project__promotional_item_ids
@@ -127,3 +130,4 @@ msgstr "Événement du spectacle"
 #: model:ir.model.fields,field_description:show_project_promotion.field_project_project__tour_poster_url
 msgid "Tour Poster"
 msgstr "Affiche du spectacle"
+

--- a/show_project_promotion/models/project_project.py
+++ b/show_project_promotion/models/project_project.py
@@ -15,6 +15,7 @@ class ProjectProject(models.Model):
     tour_poster_url = fields.Char("Tour Poster", prefetch=False)
     show_description_url = fields.Char("Show Description", prefetch=False)
     biography_url = fields.Char("Biography", prefetch=False)
+    announcement_date = fields.Date("Announcement Date", prefetch=False)
 
     promotional_item_ids = fields.One2many(
         "project.promotional.item", "project_id", "Promotional Items"

--- a/show_project_promotion/views/project_project.xml
+++ b/show_project_promotion/views/project_project.xml
@@ -14,6 +14,7 @@
                     >
                     <group>
                         <group attrs="{'invisible': [('show_type', '!=', 'show')]}">
+                            <field name="announcement_date"/>
                             <field name="show_sale_date"/>
                             <field name="distributor_platform_url" widget="url"/>
                             <field name="show_event_url" widget="url"/>

--- a/show_project_sale/i18n/fr.po
+++ b/show_project_sale/i18n/fr.po
@@ -31,11 +31,6 @@ msgid "After Real Costs"
 msgstr "Après frais réels"
 
 #. module: show_project_sale
-#: model:ir.model.fields,field_description:show_project_sale.field_project_project__announcement_date
-msgid "Announcement Date"
-msgstr "Date d’annonce"
-
-#. module: show_project_sale
 #: model_terms:ir.ui.view,arch_db:show_project_sale.show_project_sale_form
 msgid "Applicable Rate"
 msgstr "Taux applicable (%)"

--- a/show_project_sale/models/project_project.py
+++ b/show_project_sale/models/project_project.py
@@ -18,7 +18,6 @@ class ProjectProject(models.Model):
     meals = fields.Char()
     artist_favour_tickets = fields.Integer("Artist's Favour Tickets")
     diffisor_favour_tickets = fields.Integer("Diffusor's Favor Tickets")
-    announcement_date = fields.Date()
     selling_date = fields.Date()
     ticket_price_ids = fields.One2many(
         "project.ticket.price",

--- a/show_project_sale/views/project_project.xml
+++ b/show_project_sale/views/project_project.xml
@@ -33,7 +33,6 @@
                             <group>
                                 <field name="artist_favour_tickets"/>
                                 <field name="diffisor_favour_tickets"/>
-                                <field name="announcement_date"/>
                                 <field name="selling_date"/>
                             </group>
                             <group col="1">

--- a/show_sale/i18n/fr.po
+++ b/show_sale/i18n/fr.po
@@ -46,11 +46,6 @@ msgid "After Real Costs"
 msgstr "Après frais réels"
 
 #. module: show_sale
-#: model:ir.model.fields,field_description:show_sale.field_sale_order__announcement_date
-msgid "Announcement Date"
-msgstr "Date d’annonce"
-
-#. module: show_sale
 #: model_terms:ir.ui.view,arch_db:show_sale.sale_order_form
 msgid "Applicable Rate"
 msgstr "Taux applicable (%)"


### PR DESCRIPTION
Summary :

The announcement_date field will be removed from the show_sale_project module and recreated in the module
show_project_promotion.
The show_sale_date field will simply be removed from the show_project_sale module.