### PR TITLE
TA#46594 remove constraint on show sale amount

### DIFF
--- a/show_project_fee/__manifest__.py
+++ b/show_project_fee/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Show Project Fee",
     "summary": "Add management of show fees on projects",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "website": "https://bit.ly/numigi-com",
     "author": "Numigi",
     "maintainer": "Numigi",

--- a/show_project_fee/models/project_project.py
+++ b/show_project_fee/models/project_project.py
@@ -22,7 +22,6 @@ class ProjectProject(models.Model):
         if (
             not self.project_type_id
             or not self.show_member_ids
-            or not self.show_sale_amount
         ):
             raise ValidationError(
                 _(

--- a/show_project_fee/tests/test_project.py
+++ b/show_project_fee/tests/test_project.py
@@ -151,11 +151,6 @@ class TestComputeShowFees(ProjectShowFeeCase):
         with pytest.raises(ValidationError):
             self._compute_show_fees()
 
-    def test_sale_amount_not_set(self):
-        self.show.show_sale_amount = 0
-        with pytest.raises(ValidationError):
-            self._compute_show_fees()
-
     def test_no_fees_defined_on_tour(self):
         self.fee.unlink()
         with pytest.raises(ValidationError):


### PR DESCRIPTION
When testing if fees can be calculated on the project, show_sale_amount should not be tested as existing. Some shows will have a value of 0.00 in sales (free show or only on commission shows)

It should be possible to calculated the fees with a value of 0.00 in this field